### PR TITLE
Move cleanup out of condition

### DIFF
--- a/source/smu_compare_tables.sas
+++ b/source/smu_compare_tables.sas
@@ -170,10 +170,11 @@
 		proc append base=work.&summary_ds. data=work.smu_summary_new; 
 		run;
 
-		proc datasets lib=work nodetails nolist nowarn; 
-			delete smu_summary_new smu_base_contents smu_comp_contents; 
-		quit; 
 	%end; 
+
+	proc datasets lib=work nodetails nolist nowarn; 
+		delete smu_summary_new smu_base_contents smu_comp_contents; 
+	quit; 
 
 %mend smu_compare_tables; 
 


### PR DESCRIPTION
Cleanup with proc datasets was inside the conditional part to create the summary data set. In case no summary data set was requested, the cleanup was not performed. This is addressed by moving the cleanup outside of this condition. 